### PR TITLE
Added functionality for demultiplexed samples

### DIFF
--- a/pyinseq/pyinseq.py
+++ b/pyinseq/pyinseq.py
@@ -123,7 +123,6 @@ def pipeline_organize(barcodes_present, samples, source=''):
 
     if samples:
         Settings.samplesDict = sample_prep(samples, barcode_qc)
-
     else:
         d = {}
         for f in list_files(source):

--- a/pyinseq/test/test_functions.py
+++ b/pyinseq/test/test_functions.py
@@ -2,7 +2,7 @@
 import pytest
 from pyinseq import utils
 
-# pyinseq.utils.convert_to_filename
+# pyinseq.utils
 
 def test_filename_replace_spaces():
     assert utils.convert_to_filename('file name') == 'file_name'
@@ -12,3 +12,10 @@ def test_filename_leading_whitespace():
 
 def test_filename_trailing_whitespace():
     assert utils.convert_to_filename('filename  ') == 'filename'
+
+'''
+# pyinseq.pyinseq
+
+def test_set_disruption():
+    assert pyinseq.set_disruption(1.0) == 1.0
+'''


### PR DESCRIPTION
Can read all .fastq.gz files from a folder (leave out the `-s` option)
Can use samples that already have barcodes removed (`--nobarcodes`)
Current caveats:
- for these functions samples are processed in a random order (passed through a dictionary)
- requires gzipped samples, each named as .fastq.gz
- requires no other dots in the name
